### PR TITLE
Updates reference to playlist object in docs for next/prev

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -218,7 +218,7 @@ player.playlist(samplePlaylist);
 player.nextIndex();
 // 1
 
-player.next();
+player.playlist.next();
 player.nextIndex();
 // 1
 
@@ -259,7 +259,7 @@ player.playlist(samplePlaylist, 1);
 player.previousIndex();
 // 0
 
-player.previous();
+player.playlist.previous();
 player.previousIndex();
 // 0
 


### PR DESCRIPTION
## Description
Player object has no function next or previous. Docs presumably meant to target playlist object.

## Specific Changes proposed
Updates doc reference

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
