### PR TITLE
Repeat one feature

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -404,6 +404,29 @@ player.playlist.repeat();
 
 ```
 
+#### `player.playlist.repeatOne([Boolean val]) -> Boolean`
+
+Enable or disable repeat one (current) item by passing true or false as the argument.
+
+When repeatOne is enabled, the "next" video after the current video in the playlist is the same video. This affects the behavior of calling `next()`, of autoadvance, and so on.
+
+This method returns the current value. Call with no argument to use as a getter.
+
+Examples:
+
+```js
+
+player.playlist.repeatOne(true);
+
+player.playlist.repeatOne();
+// true
+
+player.playlist.repeatOne(false);
+player.playlist.repeatOne();
+// false
+
+```
+
 #### `player.playlist.sort([Function compare]) -> undefined`
 
 Sort the playlist in a manner identical to [`Array#sort`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort).

--- a/src/playlist-maker.js
+++ b/src/playlist-maker.js
@@ -308,6 +308,7 @@ export default function factory(player, initialList, initialIndex = 0) {
   playlist.player_ = player;
   playlist.autoadvance_ = {};
   playlist.repeat_ = false;
+  playlist.repeatOne_ = false;
   playlist.currentPlaylistItemId_ = null;
 
   /**
@@ -330,7 +331,7 @@ export default function factory(player, initialList, initialIndex = 0) {
     // Act as a setter when the index is given and is a valid number.
     if (
       typeof index === 'number' &&
-      playlist.currentIndex_ !== index &&
+      (playlist.currentIndex_ !== index || playlist.repeatOne_) &&
       index >= 0 &&
       index < list.length
     ) {
@@ -446,6 +447,10 @@ export default function factory(player, initialList, initialIndex = 0) {
       return -1;
     }
 
+    if (playlist.repeatOne_) {
+      return current;
+    }
+
     const lastIndex = playlist.lastIndex();
 
     // When repeating, loop back to the beginning on the last item.
@@ -469,6 +474,10 @@ export default function factory(player, initialList, initialIndex = 0) {
 
     if (current === -1) {
       return -1;
+    }
+
+    if (playlist.repeatOne_) {
+      return current;
     }
 
     // When repeating, loop back to the end of the playlist.
@@ -531,7 +540,7 @@ export default function factory(player, initialList, initialIndex = 0) {
 
     const index = playlist.nextIndex();
 
-    if (index !== playlist.currentIndex_) {
+    if (index !== playlist.currentIndex_ || playlist.repeatOne_) {
       const newItem = playlist.currentItem(index);
 
       return list[newItem].originalValue || list[newItem];
@@ -551,7 +560,7 @@ export default function factory(player, initialList, initialIndex = 0) {
 
     const index = playlist.previousIndex();
 
-    if (index !== playlist.currentIndex_) {
+    if (index !== playlist.currentIndex_ || playlist.repeatOne_) {
       const newItem = playlist.currentItem(index);
 
       return list[newItem].originalValue || list[newItem];
@@ -590,6 +599,29 @@ export default function factory(player, initialList, initialIndex = 0) {
 
     playlist.repeat_ = !!val;
     return playlist.repeat_;
+  };
+
+  /**
+   * Sets `repeatOne` option, which makes the "next" video same video as playing
+   *
+   * @param  {boolean} [val]
+   *         The value to set repeatOne to
+   *
+   * @return {boolean}
+   *         The current value of repeatOne
+   */
+  playlist.repeatOne = (val) => {
+    if (val === undefined) {
+      return playlist.repeatOne_;
+    }
+
+    if (typeof val !== 'boolean') {
+      videojs.log.error('videojs-playlist: Invalid value for repeat', val);
+      return;
+    }
+
+    playlist.repeatOne_ = !!val;
+    return playlist.repeatOne_;
   };
 
   /**

--- a/test/playlist-maker.test.js
+++ b/test/playlist-maker.test.js
@@ -502,6 +502,10 @@ QUnit.test('playlist.nextIndex() works as expected', function(assert) {
   playlist.currentItem = () => 1;
   assert.equal(playlist.nextIndex(), 2, 'the next index was 2');
 
+  playlist.repeatOne(true);
+  assert.equal(playlist.nextIndex(), 1, 'the next index was now 1 because the repeat one option is on');
+  playlist.repeatOne(false);
+
   playlist.currentItem = () => 2;
   assert.equal(playlist.nextIndex(), 2, 'the next index did not change because the playlist does not repeat');
 
@@ -520,6 +524,10 @@ QUnit.test('playlist.previousIndex() works as expected', function(assert) {
 
   playlist.currentItem = () => 1;
   assert.equal(playlist.previousIndex(), 0, 'the previous index was 0');
+
+  playlist.repeatOne(true);
+  assert.equal(playlist.nextIndex(), 1, 'the next index was now 1 because the repeat one option is on');
+  playlist.repeatOne(false);
 
   playlist.currentItem = () => 0;
   assert.equal(playlist.previousIndex(), 0, 'the previous index did not change because the playlist does not repeat');


### PR DESCRIPTION
## Description
Add ability to repeat current item in playlist

## Specific Changes proposed
Add a `repeatOne_` flag, and work with it (see in changes).

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
