### PR TITLE
feat: add `add` and `remove` methods to modify the playlist dynamically

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/*
+lts/fermium

--- a/.whitesource
+++ b/.whitesource
@@ -1,3 +1,0 @@
-{
-  "settingsInheritedFrom": "brightcove/whitesource-config@main"
-}

--- a/docs/api.md
+++ b/docs/api.md
@@ -111,61 +111,84 @@ player.playlist.currentItem();
 // -1
 ```
 
-#### `player.playlist.addItem(String|Object newItem, [Number index])`
+#### `player.playlist.add(String|Object|Array items, [Number index])`
 
 Adds an item to the current playlist without replacing the playlist.
 
-Fires the `playlistitemadded` event.
+Fires the `playlistadded` event.
 
 Calling this method during the `duringplaylistchange` event throws an error.
 
 ```js
 var samplePlaylist = [{
   sources: [{
-    src: '//media.w3.org/2010/05/sintel/trailer.mp4',
+    src: 'sintel.mp4',
     type: 'video/mp4'
   }]
 }];
 
 player.playlist(samplePlaylist);
 
-player.addItem({
+// Playlist will contain two items after this call: sintel.mp4, bbb.mp4
+player.add({
   sources: [{
-    src: '//media.w3.org/2010/05/bunny/trailer.mp4',
+    src: 'bbb.mp4',
     type: 'video/mp4'
   }]
 });
 
-// Playlist will contain 2 items now.
+// Playlist will contain four items after this call: sintel.mp4, tears.mp4, test.mp4, and bbb.mp4
+player.add([{
+  sources: [{
+    src: 'tears.mp4',
+    type: 'video/mp4'
+  }]
+}, {
+  sources: [{
+    src: 'test.mp4',
+    type: 'video/mp4'
+  }]
+}], 1);
 ```
 
+#### `player.playlist.remove(Number index, [Number count=1])`
 
-#### `player.playlist.addItem(String|Object newItem, [Number index])`
+Removes one or more items from the current playlist without replacing the playlist. By default, if `count` is not provided, one item will be removed.
 
-Adds an item to the current playlist without replacing the playlist.
-
-Fires the `playlistitemadded` event.
+Fires the `playlistremoved` event.
 
 Calling this method during the `duringplaylistchange` event throws an error.
 
 ```js
 var samplePlaylist = [{
   sources: [{
-    src: '//media.w3.org/2010/05/sintel/trailer.mp4',
+    src: 'sintel.mp4',
     type: 'video/mp4'
   }]
 }, {
   sources: [{
-    src: '//media.w3.org/2010/05/bunny/trailer.mp4',
+    src: 'bbb.mp4',
+    type: 'video/mp4'
+  }]
+}, {
+  sources: [{
+    src: 'tears.mp4',
+    type: 'video/mp4'
+  }]
+}, {
+  sources: [{
+    src: 'test.mp4',
     type: 'video/mp4'
   }]
 }];
 
 player.playlist(samplePlaylist);
 
-player.removeItem(1);
+// Playlist will contain three items after this call: bbb.mp4, tears.mp4, and test.mp4
+player.remove(0);
 
-// Playlist will only contain 1 item now.
+// Playlist will contain one item after this call: bbb.mp4
+player.remove(1, 2);
 ```
 
 #### `player.playlist.contains(String|Object|Array value) -> Boolean`

--- a/docs/api.md
+++ b/docs/api.md
@@ -113,9 +113,9 @@ player.playlist.currentItem();
 
 #### `player.playlist.add(String|Object|Array items, [Number index])`
 
-Adds an item to the current playlist without replacing the playlist.
+Adds one or more items to the current playlist without replacing the playlist.
 
-Fires the `playlistadded` event.
+Fires the `playlistadd` event.
 
 Calling this method during the `duringplaylistchange` event throws an error.
 
@@ -155,7 +155,7 @@ player.add([{
 
 Removes one or more items from the current playlist without replacing the playlist. By default, if `count` is not provided, one item will be removed.
 
-Fires the `playlistremoved` event.
+Fires the `playlistremove` event.
 
 Calling this method during the `duringplaylistchange` event throws an error.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,13 +2,7 @@
 
 ## Playlist Item Object
 
-A playlist is an array of playlist items. A playlist item is an object with the following properties:
-
-| Property     | Type   | Optional | Description                                        |
-| ------------ | ------ | -------- | -------------------------------------------------- |
-| `sources`    | Array  |          | An array of sources that video.js understands.     |
-| `poster`     | String | ✓        | A poster image to display for these sources.       |
-| `textTracks` | Array  | ✓        | An array of text tracks that Video.js understands. |
+A playlist is an array of playlist items. Usually, a playlist item is an object with an array of `sources`, but it could also be a primitive value like a string.
 
 ## Methods
 ### `player.playlist([Array newList], [Number newIndex]) -> Array`
@@ -20,43 +14,43 @@ If called without arguments, it is a getter. With an argument, it is a setter.
 ```js
 player.playlist([{
   sources: [{
-    src: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
+    src: '//media.w3.org/2010/05/sintel/trailer.mp4',
     type: 'video/mp4'
   }],
-  poster: 'http://media.w3.org/2010/05/sintel/poster.png'
+  poster: '//media.w3.org/2010/05/sintel/poster.png'
 }, {
   sources: [{
-    src: 'http://media.w3.org/2010/05/bunny/trailer.mp4',
+    src: '//media.w3.org/2010/05/bunny/trailer.mp4',
     type: 'video/mp4'
   }],
-  poster: 'http://media.w3.org/2010/05/bunny/poster.png'
+  poster: '//media.w3.org/2010/05/bunny/poster.png'
 }, {
   sources: [{
-    src: 'http://vjs.zencdn.net/v/oceans.mp4',
+    src: '//vjs.zencdn.net/v/oceans.mp4',
     type: 'video/mp4'
   }],
-  poster: 'http://www.videojs.com/img/poster.jpg'
+  poster: '//www.videojs.com/img/poster.jpg'
 }, {
   sources: [{
-    src: 'http://media.w3.org/2010/05/bunny/movie.mp4',
+    src: '//media.w3.org/2010/05/bunny/movie.mp4',
     type: 'video/mp4'
   }],
-  poster: 'http://media.w3.org/2010/05/bunny/poster.png'
+  poster: '//media.w3.org/2010/05/bunny/poster.png'
 }, {
   sources: [{
-    src: 'http://media.w3.org/2010/05/video/movie_300.mp4',
+    src: '//media.w3.org/2010/05/video/movie_300.mp4',
     type: 'video/mp4'
   }],
-  poster: 'http://media.w3.org/2010/05/video/poster.png'
+  poster: '//media.w3.org/2010/05/video/poster.png'
 }]);
 // [{ ... }, ... ]
 
 player.playlist([{
   sources: [{
-    src: 'http://media.w3.org/2010/05/video/movie_300.mp4',
+    src: '//media.w3.org/2010/05/video/movie_300.mp4',
     type: 'video/mp4'
   }],
-  poster: 'http://media.w3.org/2010/05/video/poster.png'
+  poster: '//media.w3.org/2010/05/video/poster.png'
 }]);
 // [{ ... }]
 ```
@@ -67,16 +61,16 @@ first video is loaded. If `-1`, no video is loaded.
 ```js
 player.playlist([{
   sources: [{
-    src: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
+    src: '//media.w3.org/2010/05/sintel/trailer.mp4',
     type: 'video/mp4'
   }],
-  poster: 'http://media.w3.org/2010/05/sintel/poster.png'
+  poster: '//media.w3.org/2010/05/sintel/poster.png'
 }, {
   sources: [{
-    src: 'http://media.w3.org/2010/05/bunny/trailer.mp4',
+    src: '//media.w3.org/2010/05/bunny/trailer.mp4',
     type: 'video/mp4'
   }],
-  poster: 'http://media.w3.org/2010/05/bunny/poster.png'
+  poster: '//media.w3.org/2010/05/bunny/poster.png'
 }], 1);
 // [{ ... }]
 ```
@@ -92,16 +86,16 @@ If the player is currently playing a non-playlist video, it will return `-1`.
 ```js
 var samplePlaylist = [{
   sources: [{
-    src: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
+    src: '//media.w3.org/2010/05/sintel/trailer.mp4',
     type: 'video/mp4'
   }],
-  poster: 'http://media.w3.org/2010/05/sintel/poster.png'
+  poster: '//media.w3.org/2010/05/sintel/poster.png'
 }, {
   sources: [{
-    src: 'http://media.w3.org/2010/05/bunny/trailer.mp4',
+    src: '//media.w3.org/2010/05/bunny/trailer.mp4',
     type: 'video/mp4'
   }],
-  poster: 'http://media.w3.org/2010/05/bunny/poster.png'
+  poster: '//media.w3.org/2010/05/bunny/poster.png'
 }];
 
 player.playlist(samplePlaylist);
@@ -112,9 +106,66 @@ player.currentItem();
 player.currentItem(2);
 // 2
 
-player.src('http://example.com/video.mp4');
+player.src('//example.com/video.mp4');
 player.playlist.currentItem();
 // -1
+```
+
+#### `player.playlist.addItem(String|Object newItem, [Number index])`
+
+Adds an item to the current playlist without replacing the playlist.
+
+Fires the `playlistitemadded` event.
+
+Calling this method during the `duringplaylistchange` event throws an error.
+
+```js
+var samplePlaylist = [{
+  sources: [{
+    src: '//media.w3.org/2010/05/sintel/trailer.mp4',
+    type: 'video/mp4'
+  }]
+}];
+
+player.playlist(samplePlaylist);
+
+player.addItem({
+  sources: [{
+    src: '//media.w3.org/2010/05/bunny/trailer.mp4',
+    type: 'video/mp4'
+  }]
+});
+
+// Playlist will contain 2 items now.
+```
+
+
+#### `player.playlist.addItem(String|Object newItem, [Number index])`
+
+Adds an item to the current playlist without replacing the playlist.
+
+Fires the `playlistitemadded` event.
+
+Calling this method during the `duringplaylistchange` event throws an error.
+
+```js
+var samplePlaylist = [{
+  sources: [{
+    src: '//media.w3.org/2010/05/sintel/trailer.mp4',
+    type: 'video/mp4'
+  }]
+}, {
+  sources: [{
+    src: '//media.w3.org/2010/05/bunny/trailer.mp4',
+    type: 'video/mp4'
+  }]
+}];
+
+player.playlist(samplePlaylist);
+
+player.removeItem(1);
+
+// Playlist will only contain 1 item now.
 ```
 
 #### `player.playlist.contains(String|Object|Array value) -> Boolean`
@@ -124,18 +175,18 @@ Determine whether a string, source object, or playlist item is contained within 
 Assuming the playlist used above, consider the following example:
 
 ```js
-player.playlist.contains('http://media.w3.org/2010/05/sintel/trailer.mp4');
+player.playlist.contains('//media.w3.org/2010/05/sintel/trailer.mp4');
 // true
 
 player.playlist.contains([{
-  src: 'http://media.w3.org/2010/05/sintel/poster.png',
+  src: '//media.w3.org/2010/05/sintel/poster.png',
   type: 'image/png'
 }]);
 // false
 
 player.playlist.contains({
   sources: [{
-    src: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
+    src: '//media.w3.org/2010/05/sintel/trailer.mp4',
     type: 'video/mp4'
   }]
 });
@@ -149,18 +200,18 @@ Get the index of a string, source object, or playlist item in the playlist. If n
 Assuming the playlist used above, consider the following example:
 
 ```js
-player.playlist.indexOf('http://media.w3.org/2010/05/bunny/trailer.mp4');
+player.playlist.indexOf('//media.w3.org/2010/05/bunny/trailer.mp4');
 // 1
 
 player.playlist.indexOf([{
-  src: 'http://media.w3.org/2010/05/bunny/movie.mp4',
+  src: '//media.w3.org/2010/05/bunny/movie.mp4',
   type: 'video/mp4'
 }]);
 // 3
 
 player.playlist.indexOf({
   sources: [{
-    src: 'http://media.w3.org/2010/05/video/movie_300.mp4',
+    src: '//media.w3.org/2010/05/video/movie_300.mp4',
     type: 'video/mp4'
   }]
 });
@@ -174,16 +225,16 @@ Get the index of the current item in the playlist. This is identical to calling 
 ```js
 var samplePlaylist = [{
   sources: [{
-    src: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
+    src: '//media.w3.org/2010/05/sintel/trailer.mp4',
     type: 'video/mp4'
   }],
-  poster: 'http://media.w3.org/2010/05/sintel/poster.png'
+  poster: '//media.w3.org/2010/05/sintel/poster.png'
 }, {
   sources: [{
-    src: 'http://media.w3.org/2010/05/bunny/trailer.mp4',
+    src: '//media.w3.org/2010/05/bunny/trailer.mp4',
     type: 'video/mp4'
   }],
-  poster: 'http://media.w3.org/2010/05/bunny/poster.png'
+  poster: '//media.w3.org/2010/05/bunny/poster.png'
 }];
 
 player.currentIndex();
@@ -201,16 +252,16 @@ If the player is currently playing a non-playlist video, it will return `-1`.
 ```js
 var samplePlaylist = [{
   sources: [{
-    src: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
+    src: '//media.w3.org/2010/05/sintel/trailer.mp4',
     type: 'video/mp4'
   }],
-  poster: 'http://media.w3.org/2010/05/sintel/poster.png'
+  poster: '//media.w3.org/2010/05/sintel/poster.png'
 }, {
   sources: [{
-    src: 'http://media.w3.org/2010/05/bunny/trailer.mp4',
+    src: '//media.w3.org/2010/05/bunny/trailer.mp4',
     type: 'video/mp4'
   }],
-  poster: 'http://media.w3.org/2010/05/bunny/poster.png'
+  poster: '//media.w3.org/2010/05/bunny/poster.png'
 }];
 
 player.playlist(samplePlaylist);
@@ -226,7 +277,7 @@ player.repeat(true);
 player.nextIndex();
 // 0
 
-player.src('http://example.com/video.mp4');
+player.src('//example.com/video.mp4');
 player.playlist.nextIndex();
 // -1
 ```
@@ -242,16 +293,16 @@ If the player is currently playing a non-playlist video, it will return `-1`.
 ```js
 var samplePlaylist = [{
   sources: [{
-    src: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
+    src: '//media.w3.org/2010/05/sintel/trailer.mp4',
     type: 'video/mp4'
   }],
-  poster: 'http://media.w3.org/2010/05/sintel/poster.png'
+  poster: '//media.w3.org/2010/05/sintel/poster.png'
 }, {
   sources: [{
-    src: 'http://media.w3.org/2010/05/bunny/trailer.mp4',
+    src: '//media.w3.org/2010/05/bunny/trailer.mp4',
     type: 'video/mp4'
   }],
-  poster: 'http://media.w3.org/2010/05/bunny/poster.png'
+  poster: '//media.w3.org/2010/05/bunny/poster.png'
 }];
 
 player.playlist(samplePlaylist, 1);
@@ -267,7 +318,7 @@ player.repeat(true);
 player.previousIndex();
 // 1
 
-player.src('http://example.com/video.mp4');
+player.src('//example.com/video.mp4');
 player.playlist.previousIndex();
 // -1
 ```
@@ -279,16 +330,16 @@ Get the index of the last item in the playlist.
 ```js
 var samplePlaylist = [{
   sources: [{
-    src: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
+    src: '//media.w3.org/2010/05/sintel/trailer.mp4',
     type: 'video/mp4'
   }],
-  poster: 'http://media.w3.org/2010/05/sintel/poster.png'
+  poster: '//media.w3.org/2010/05/sintel/poster.png'
 }, {
   sources: [{
-    src: 'http://media.w3.org/2010/05/bunny/trailer.mp4',
+    src: '//media.w3.org/2010/05/bunny/trailer.mp4',
     type: 'video/mp4'
   }],
-  poster: 'http://media.w3.org/2010/05/bunny/poster.png'
+  poster: '//media.w3.org/2010/05/bunny/poster.png'
 }];
 
 player.lastIndex();

--- a/docs/api.md
+++ b/docs/api.md
@@ -538,9 +538,9 @@ player.on('playlistchange', function() {
 
 ### `playlistchange`
 
-This event is fired _asynchronously_ whenever the contents of the playlist are changed (i.e., when `player.playlist()` is called with an argument) - except the first time.
+This event is fired whenever the contents of the playlist are changed (i.e., when `player.playlist()` is called with an argument) - except the first time. Additionally, it is fired when item(s) are added or removed from the playlist.
 
-It is fired asynchronously to let the browser start loading the first video in the new playlist.
+In cases where a change to the playlist may result in a new video source being loaded, it is fired asynchronously to let the browser start loading the first video in the new playlist.
 
 ```js
 player.on('playlistchange', function() {
@@ -553,6 +553,16 @@ player.playlist([]);
 player.playlist([]);
 // [ ... ]
 ```
+
+#### `action`
+
+Each `playlistchange` event object has an additional `action` property. This can help you identify the action that caused the `playlistchange` event to be triggered. It will be one of:
+
+* `add`: One or more items were added to the playlist
+* `change`: The entire playlist was replaced
+* `remove`: One or more items were removed from the playlist
+
+This is considered temporary/deprecated behavior because future implementations should only fire the `playlistadd` and `playlistremove` events.
 
 #### Backward Compatibility
 
@@ -567,6 +577,14 @@ player.playlist([...]);
 ```
 
 This behavior will be removed in v5.0.0 and the event will fire in all cases.
+
+### `playlistadd`
+
+One or more items were added to the playlist via the `playlist.add()` method.
+
+### `playlistremove`
+
+One or more items were removed from the playlist via the `playlist.remove()` method.
 
 ### `beforeplaylistitem`
 

--- a/src/playlist-maker.js
+++ b/src/playlist-maker.js
@@ -260,7 +260,7 @@ export default function factory(player, initialList, initialIndex = 0) {
       // @todo - Remove this condition in preparation for v5.
       if (previousPlaylist) {
         player.setTimeout(() => {
-          player.trigger('playlistchange');
+          player.trigger({type: 'playlistchange', action: 'change'});
         }, 0);
       }
     }
@@ -410,7 +410,7 @@ export default function factory(player, initialList, initialIndex = 0) {
 
     // playlistchange is triggered synchronously in this case because it does
     // not change the current media source
-    player.trigger('playlistchange');
+    player.trigger({type: 'playlistchange', action: 'add'});
     player.trigger({type: 'playlistadd', count: items.length, index});
   };
 
@@ -441,7 +441,7 @@ export default function factory(player, initialList, initialIndex = 0) {
 
     // playlistchange is triggered synchronously in this case because it does
     // not change the current media source
-    player.trigger('playlistchange');
+    player.trigger({type: 'playlistchange', action: 'remove'});
     player.trigger({type: 'playlistremove', count, index});
   };
 

--- a/src/playlist-maker.js
+++ b/src/playlist-maker.js
@@ -407,6 +407,10 @@ export default function factory(player, initialList, initialIndex = 0) {
       items = [items];
     }
     list.splice(index, 0, ...preparePlaylistItems(items));
+
+    // playlistchange is triggered synchronously in this case because it does
+    // not change the current media source
+    player.trigger('playlistchange');
     player.trigger({type: 'playlistadd', count: items.length, index});
   };
 
@@ -434,6 +438,10 @@ export default function factory(player, initialList, initialIndex = 0) {
       return;
     }
     list.splice(index, count);
+
+    // playlistchange is triggered synchronously in this case because it does
+    // not change the current media source
+    player.trigger('playlistchange');
     player.trigger({type: 'playlistremove', count, index});
   };
 

--- a/src/playlist-maker.js
+++ b/src/playlist-maker.js
@@ -15,8 +15,6 @@ let guid = 1;
  * used to determine the index of an item in the playlist array in cases where
  * there are multiple otherwise identical items.
  *
- * Also adds
- *
  * @param  {Object} newItem
  *         An playlist item object, but accepts any value.
  *

--- a/test/playlist-maker.test.js
+++ b/test/playlist-maker.test.js
@@ -890,98 +890,143 @@ QUnit.test('playlist.shuffle({rest: true}) works as expected', function(assert) 
   assert.strictEqual(spy.callCount, 3, 'the "playlistsorted" event triggered');
 });
 
-QUnit.test('playlist.addItem appends items by default', function(assert) {
+QUnit.test('playlist.add will append an item by default', function(assert) {
   const player = playerProxyMaker();
   const playlist = playlistMaker(player, [1, 2, 3]);
   const spy = sinon.spy();
 
   this.clock.tick(1);
-  player.on(['playlistchange', 'playlistitemadded'], spy);
-  playlist.addItem(4);
+  player.on('playlistadd', spy);
+  playlist.add(4);
   assert.deepEqual(playlist(), [1, 2, 3, 4]);
-  assert.strictEqual(spy.callCount, 2);
-  assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
-  assert.strictEqual(spy.secondCall.args[0].type, 'playlistitemadded');
-  assert.strictEqual(spy.secondCall.args[0].index, 3);
+  assert.strictEqual(spy.callCount, 1);
+  assert.strictEqual(spy.firstCall.args[0].type, 'playlistadd');
+  assert.strictEqual(spy.firstCall.args[0].index, 3);
+  assert.strictEqual(spy.firstCall.args[0].count, 1);
 });
 
-QUnit.test('playlist.addItem can insert an item at a specific index', function(assert) {
+QUnit.test('playlist.add can insert an item at a specific index', function(assert) {
   const player = playerProxyMaker();
   const playlist = playlistMaker(player, [1, 2, 3]);
   const spy = sinon.spy();
 
   this.clock.tick(1);
-  player.on(['playlistchange', 'playlistitemadded'], spy);
-  playlist.addItem(4, 1);
+  player.on('playlistadd', spy);
+  playlist.add(4, 1);
   assert.deepEqual(playlist(), [1, 4, 2, 3]);
-  assert.strictEqual(spy.callCount, 2);
-  assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
-  assert.strictEqual(spy.secondCall.args[0].type, 'playlistitemadded');
-  assert.strictEqual(spy.secondCall.args[0].index, 1);
+  assert.strictEqual(spy.callCount, 1);
+  assert.strictEqual(spy.firstCall.args[0].type, 'playlistadd');
+  assert.strictEqual(spy.firstCall.args[0].index, 1);
+  assert.strictEqual(spy.firstCall.args[0].count, 1);
 });
 
-QUnit.test('playlist.addItem does nothing when specified index is out of bounds', function(assert) {
+QUnit.test('playlist.add appends when specified index is out of bounds', function(assert) {
   const player = playerProxyMaker();
   const playlist = playlistMaker(player, [1, 2, 3]);
   const spy = sinon.spy();
 
   this.clock.tick(1);
-  player.on(['playlistchange', 'playlistitemadded'], spy);
-  playlist.addItem(4, 10);
+  player.on('playlistadd', spy);
+  playlist.add(4, 10);
   assert.deepEqual(playlist(), [1, 2, 3, 4]);
-  assert.strictEqual(spy.callCount, 2);
-  assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
-  assert.strictEqual(spy.secondCall.args[0].type, 'playlistitemadded');
-  assert.strictEqual(spy.secondCall.args[0].index, 3);
+  assert.strictEqual(spy.callCount, 1);
+  assert.strictEqual(spy.firstCall.args[0].type, 'playlistadd');
+  assert.strictEqual(spy.firstCall.args[0].index, 3);
+  assert.strictEqual(spy.firstCall.args[0].count, 1);
 });
 
-QUnit.test('playlist.addItem throws an error duringplaylistchange', function(assert) {
+QUnit.test('playlist.add can append multiple items', function(assert) {
+  const player = playerProxyMaker();
+  const playlist = playlistMaker(player, [1, 2, 3]);
+  const spy = sinon.spy();
+
+  this.clock.tick(1);
+  player.on('playlistadd', spy);
+  playlist.add([4, 5, 6]);
+  assert.deepEqual(playlist(), [1, 2, 3, 4, 5, 6]);
+  assert.strictEqual(spy.callCount, 1);
+  assert.strictEqual(spy.firstCall.args[0].type, 'playlistadd');
+  assert.strictEqual(spy.firstCall.args[0].index, 3);
+  assert.strictEqual(spy.firstCall.args[0].count, 3);
+});
+
+QUnit.test('playlist.add can insert multiple items at a specific index', function(assert) {
+  const player = playerProxyMaker();
+  const playlist = playlistMaker(player, [1, 2, 3]);
+  const spy = sinon.spy();
+
+  this.clock.tick(1);
+  player.on('playlistadd', spy);
+  playlist.add([4, 5, 6, 7], 1);
+  assert.deepEqual(playlist(), [1, 4, 5, 6, 7, 2, 3]);
+  assert.strictEqual(spy.callCount, 1);
+  assert.strictEqual(spy.firstCall.args[0].type, 'playlistadd');
+  assert.strictEqual(spy.firstCall.args[0].index, 1);
+  assert.strictEqual(spy.firstCall.args[0].count, 4);
+});
+
+QUnit.test('playlist.add throws an error duringplaylistchange', function(assert) {
   const done = assert.async();
   const player = playerProxyMaker();
   const playlist = playlistMaker(player, [1, 2, 3]);
 
   player.on('duringplaylistchange', (e) => {
-    assert.throws(() => playlist.addItem(4));
+    assert.throws(() => playlist.add(4));
     done();
   });
 
   playlist([4, 5, 6]);
 });
 
-QUnit.test('playlist.removeItem removes an item at an index', function(assert) {
+QUnit.test('playlist.remove can remove an item at an index', function(assert) {
   const player = playerProxyMaker();
   const playlist = playlistMaker(player, [1, 2, 3]);
   const spy = sinon.spy();
 
   this.clock.tick(1);
-  player.on(['playlistchange', 'playlistitemremoved'], spy);
-  playlist.removeItem(1);
+  player.on('playlistremove', spy);
+  playlist.remove(1);
   assert.deepEqual(playlist(), [1, 3]);
-  assert.strictEqual(spy.callCount, 2);
-  assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
-  assert.strictEqual(spy.secondCall.args[0].type, 'playlistitemremoved');
-  assert.strictEqual(spy.secondCall.args[0].index, 1);
+  assert.strictEqual(spy.callCount, 1);
+  assert.strictEqual(spy.firstCall.args[0].type, 'playlistremove');
+  assert.strictEqual(spy.firstCall.args[0].index, 1);
+  assert.strictEqual(spy.firstCall.args[0].count, 1);
 });
 
-QUnit.test('playlist.removeItem does nothing when index is out of range', function(assert) {
+QUnit.test('playlist.remove does nothing when index is out of range', function(assert) {
   const player = playerProxyMaker();
   const playlist = playlistMaker(player, [1, 2, 3]);
   const spy = sinon.spy();
 
   this.clock.tick(1);
-  player.on(['playlistchange', 'playlistitemremoved'], spy);
-  playlist.removeItem(4);
+  player.on('playlistremove', spy);
+  playlist.remove(4);
   assert.deepEqual(playlist(), [1, 2, 3]);
   assert.strictEqual(spy.callCount, 0);
 });
 
-QUnit.test('playlist.removeItem throws an error duringplaylistchange', function(assert) {
+QUnit.test('playlist.remove can remove multiple items at an index', function(assert) {
+  const player = playerProxyMaker();
+  const playlist = playlistMaker(player, [1, 2, 3]);
+  const spy = sinon.spy();
+
+  this.clock.tick(1);
+  player.on('playlistremove', spy);
+  playlist.remove(1, 2);
+  assert.deepEqual(playlist(), [1]);
+  assert.strictEqual(spy.callCount, 1);
+  assert.strictEqual(spy.firstCall.args[0].type, 'playlistremove');
+  assert.strictEqual(spy.firstCall.args[0].index, 1);
+  assert.strictEqual(spy.firstCall.args[0].count, 2);
+});
+
+QUnit.test('playlist.remove throws an error duringplaylistchange', function(assert) {
   const done = assert.async();
   const player = playerProxyMaker();
   const playlist = playlistMaker(player, [1, 2, 3]);
 
   player.on('duringplaylistchange', (e) => {
-    assert.throws(() => playlist.removeItem(0));
+    assert.throws(() => playlist.remove(0));
     done();
   });
 

--- a/test/playlist-maker.test.js
+++ b/test/playlist-maker.test.js
@@ -712,6 +712,7 @@ QUnit.test('when loading a new playlist, trigger "playlistchange" on the player'
 
   assert.strictEqual(spy.callCount, 1);
   assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+  assert.strictEqual(spy.firstCall.args[0].action, 'change');
 });
 
 QUnit.test('"duringplaylistchange" and "playlistchange" on first call without an initial list', function(assert) {
@@ -901,6 +902,7 @@ QUnit.test('playlist.add will append an item by default', function(assert) {
   assert.deepEqual(playlist(), [1, 2, 3, 4]);
   assert.strictEqual(spy.callCount, 2);
   assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+  assert.strictEqual(spy.firstCall.args[0].action, 'add');
   assert.strictEqual(spy.secondCall.args[0].type, 'playlistadd');
   assert.strictEqual(spy.secondCall.args[0].index, 3);
   assert.strictEqual(spy.secondCall.args[0].count, 1);
@@ -917,6 +919,7 @@ QUnit.test('playlist.add can insert an item at a specific index', function(asser
   assert.deepEqual(playlist(), [1, 4, 2, 3]);
   assert.strictEqual(spy.callCount, 2);
   assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+  assert.strictEqual(spy.firstCall.args[0].action, 'add');
   assert.strictEqual(spy.secondCall.args[0].type, 'playlistadd');
   assert.strictEqual(spy.secondCall.args[0].index, 1);
   assert.strictEqual(spy.secondCall.args[0].count, 1);
@@ -933,6 +936,7 @@ QUnit.test('playlist.add appends when specified index is out of bounds', functio
   assert.deepEqual(playlist(), [1, 2, 3, 4]);
   assert.strictEqual(spy.callCount, 2);
   assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+  assert.strictEqual(spy.firstCall.args[0].action, 'add');
   assert.strictEqual(spy.secondCall.args[0].type, 'playlistadd');
   assert.strictEqual(spy.secondCall.args[0].index, 3);
   assert.strictEqual(spy.secondCall.args[0].count, 1);
@@ -949,6 +953,7 @@ QUnit.test('playlist.add can append multiple items', function(assert) {
   assert.deepEqual(playlist(), [1, 2, 3, 4, 5, 6]);
   assert.strictEqual(spy.callCount, 2);
   assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+  assert.strictEqual(spy.firstCall.args[0].action, 'add');
   assert.strictEqual(spy.secondCall.args[0].type, 'playlistadd');
   assert.strictEqual(spy.secondCall.args[0].index, 3);
   assert.strictEqual(spy.secondCall.args[0].count, 3);
@@ -965,6 +970,7 @@ QUnit.test('playlist.add can insert multiple items at a specific index', functio
   assert.deepEqual(playlist(), [1, 4, 5, 6, 7, 2, 3]);
   assert.strictEqual(spy.callCount, 2);
   assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+  assert.strictEqual(spy.firstCall.args[0].action, 'add');
   assert.strictEqual(spy.secondCall.args[0].type, 'playlistadd');
   assert.strictEqual(spy.secondCall.args[0].index, 1);
   assert.strictEqual(spy.secondCall.args[0].count, 4);
@@ -994,6 +1000,7 @@ QUnit.test('playlist.remove can remove an item at an index', function(assert) {
   assert.deepEqual(playlist(), [1, 3]);
   assert.strictEqual(spy.callCount, 2);
   assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+  assert.strictEqual(spy.firstCall.args[0].action, 'remove');
   assert.strictEqual(spy.secondCall.args[0].type, 'playlistremove');
   assert.strictEqual(spy.secondCall.args[0].index, 1);
   assert.strictEqual(spy.secondCall.args[0].count, 1);
@@ -1022,6 +1029,7 @@ QUnit.test('playlist.remove can remove multiple items at an index', function(ass
   assert.deepEqual(playlist(), [1]);
   assert.strictEqual(spy.callCount, 2);
   assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+  assert.strictEqual(spy.firstCall.args[0].action, 'remove');
   assert.strictEqual(spy.secondCall.args[0].type, 'playlistremove');
   assert.strictEqual(spy.secondCall.args[0].index, 1);
   assert.strictEqual(spy.secondCall.args[0].count, 2);

--- a/test/playlist-maker.test.js
+++ b/test/playlist-maker.test.js
@@ -889,3 +889,101 @@ QUnit.test('playlist.shuffle({rest: true}) works as expected', function(assert) 
   assert.notStrictEqual(list.indexOf(4), -1, '4 is in the list');
   assert.strictEqual(spy.callCount, 3, 'the "playlistsorted" event triggered');
 });
+
+QUnit.test('playlist.addItem appends items by default', function(assert) {
+  const player = playerProxyMaker();
+  const playlist = playlistMaker(player, [1, 2, 3]);
+  const spy = sinon.spy();
+
+  this.clock.tick(1);
+  player.on(['playlistchange', 'playlistitemadded'], spy);
+  playlist.addItem(4);
+  assert.deepEqual(playlist(), [1, 2, 3, 4]);
+  assert.strictEqual(spy.callCount, 2);
+  assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+  assert.strictEqual(spy.secondCall.args[0].type, 'playlistitemadded');
+  assert.strictEqual(spy.secondCall.args[0].index, 3);
+});
+
+QUnit.test('playlist.addItem can insert an item at a specific index', function(assert) {
+  const player = playerProxyMaker();
+  const playlist = playlistMaker(player, [1, 2, 3]);
+  const spy = sinon.spy();
+
+  this.clock.tick(1);
+  player.on(['playlistchange', 'playlistitemadded'], spy);
+  playlist.addItem(4, 1);
+  assert.deepEqual(playlist(), [1, 4, 2, 3]);
+  assert.strictEqual(spy.callCount, 2);
+  assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+  assert.strictEqual(spy.secondCall.args[0].type, 'playlistitemadded');
+  assert.strictEqual(spy.secondCall.args[0].index, 1);
+});
+
+QUnit.test('playlist.addItem does nothing when specified index is out of bounds', function(assert) {
+  const player = playerProxyMaker();
+  const playlist = playlistMaker(player, [1, 2, 3]);
+  const spy = sinon.spy();
+
+  this.clock.tick(1);
+  player.on(['playlistchange', 'playlistitemadded'], spy);
+  playlist.addItem(4, 10);
+  assert.deepEqual(playlist(), [1, 2, 3, 4]);
+  assert.strictEqual(spy.callCount, 2);
+  assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+  assert.strictEqual(spy.secondCall.args[0].type, 'playlistitemadded');
+  assert.strictEqual(spy.secondCall.args[0].index, 3);
+});
+
+QUnit.test('playlist.addItem throws an error duringplaylistchange', function(assert) {
+  const done = assert.async();
+  const player = playerProxyMaker();
+  const playlist = playlistMaker(player, [1, 2, 3]);
+
+  player.on('duringplaylistchange', (e) => {
+    assert.throws(() => playlist.addItem(4));
+    done();
+  });
+
+  playlist([4, 5, 6]);
+});
+
+QUnit.test('playlist.removeItem removes an item at an index', function(assert) {
+  const player = playerProxyMaker();
+  const playlist = playlistMaker(player, [1, 2, 3]);
+  const spy = sinon.spy();
+
+  this.clock.tick(1);
+  player.on(['playlistchange', 'playlistitemremoved'], spy);
+  playlist.removeItem(1);
+  assert.deepEqual(playlist(), [1, 3]);
+  assert.strictEqual(spy.callCount, 2);
+  assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+  assert.strictEqual(spy.secondCall.args[0].type, 'playlistitemremoved');
+  assert.strictEqual(spy.secondCall.args[0].index, 1);
+});
+
+QUnit.test('playlist.removeItem does nothing when index is out of range', function(assert) {
+  const player = playerProxyMaker();
+  const playlist = playlistMaker(player, [1, 2, 3]);
+  const spy = sinon.spy();
+
+  this.clock.tick(1);
+  player.on(['playlistchange', 'playlistitemremoved'], spy);
+  playlist.removeItem(4);
+  assert.deepEqual(playlist(), [1, 2, 3]);
+  assert.strictEqual(spy.callCount, 0);
+});
+
+QUnit.test('playlist.removeItem throws an error duringplaylistchange', function(assert) {
+  const done = assert.async();
+  const player = playerProxyMaker();
+  const playlist = playlistMaker(player, [1, 2, 3]);
+
+  player.on('duringplaylistchange', (e) => {
+    assert.throws(() => playlist.removeItem(0));
+    done();
+  });
+
+  playlist([4, 5, 6]);
+});

--- a/test/playlist-maker.test.js
+++ b/test/playlist-maker.test.js
@@ -896,13 +896,14 @@ QUnit.test('playlist.add will append an item by default', function(assert) {
   const spy = sinon.spy();
 
   this.clock.tick(1);
-  player.on('playlistadd', spy);
+  player.on(['playlistchange', 'playlistadd'], spy);
   playlist.add(4);
   assert.deepEqual(playlist(), [1, 2, 3, 4]);
-  assert.strictEqual(spy.callCount, 1);
-  assert.strictEqual(spy.firstCall.args[0].type, 'playlistadd');
-  assert.strictEqual(spy.firstCall.args[0].index, 3);
-  assert.strictEqual(spy.firstCall.args[0].count, 1);
+  assert.strictEqual(spy.callCount, 2);
+  assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+  assert.strictEqual(spy.secondCall.args[0].type, 'playlistadd');
+  assert.strictEqual(spy.secondCall.args[0].index, 3);
+  assert.strictEqual(spy.secondCall.args[0].count, 1);
 });
 
 QUnit.test('playlist.add can insert an item at a specific index', function(assert) {
@@ -911,13 +912,14 @@ QUnit.test('playlist.add can insert an item at a specific index', function(asser
   const spy = sinon.spy();
 
   this.clock.tick(1);
-  player.on('playlistadd', spy);
+  player.on(['playlistchange', 'playlistadd'], spy);
   playlist.add(4, 1);
   assert.deepEqual(playlist(), [1, 4, 2, 3]);
-  assert.strictEqual(spy.callCount, 1);
-  assert.strictEqual(spy.firstCall.args[0].type, 'playlistadd');
-  assert.strictEqual(spy.firstCall.args[0].index, 1);
-  assert.strictEqual(spy.firstCall.args[0].count, 1);
+  assert.strictEqual(spy.callCount, 2);
+  assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+  assert.strictEqual(spy.secondCall.args[0].type, 'playlistadd');
+  assert.strictEqual(spy.secondCall.args[0].index, 1);
+  assert.strictEqual(spy.secondCall.args[0].count, 1);
 });
 
 QUnit.test('playlist.add appends when specified index is out of bounds', function(assert) {
@@ -926,13 +928,14 @@ QUnit.test('playlist.add appends when specified index is out of bounds', functio
   const spy = sinon.spy();
 
   this.clock.tick(1);
-  player.on('playlistadd', spy);
+  player.on(['playlistchange', 'playlistadd'], spy);
   playlist.add(4, 10);
   assert.deepEqual(playlist(), [1, 2, 3, 4]);
-  assert.strictEqual(spy.callCount, 1);
-  assert.strictEqual(spy.firstCall.args[0].type, 'playlistadd');
-  assert.strictEqual(spy.firstCall.args[0].index, 3);
-  assert.strictEqual(spy.firstCall.args[0].count, 1);
+  assert.strictEqual(spy.callCount, 2);
+  assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+  assert.strictEqual(spy.secondCall.args[0].type, 'playlistadd');
+  assert.strictEqual(spy.secondCall.args[0].index, 3);
+  assert.strictEqual(spy.secondCall.args[0].count, 1);
 });
 
 QUnit.test('playlist.add can append multiple items', function(assert) {
@@ -941,13 +944,14 @@ QUnit.test('playlist.add can append multiple items', function(assert) {
   const spy = sinon.spy();
 
   this.clock.tick(1);
-  player.on('playlistadd', spy);
+  player.on(['playlistchange', 'playlistadd'], spy);
   playlist.add([4, 5, 6]);
   assert.deepEqual(playlist(), [1, 2, 3, 4, 5, 6]);
-  assert.strictEqual(spy.callCount, 1);
-  assert.strictEqual(spy.firstCall.args[0].type, 'playlistadd');
-  assert.strictEqual(spy.firstCall.args[0].index, 3);
-  assert.strictEqual(spy.firstCall.args[0].count, 3);
+  assert.strictEqual(spy.callCount, 2);
+  assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+  assert.strictEqual(spy.secondCall.args[0].type, 'playlistadd');
+  assert.strictEqual(spy.secondCall.args[0].index, 3);
+  assert.strictEqual(spy.secondCall.args[0].count, 3);
 });
 
 QUnit.test('playlist.add can insert multiple items at a specific index', function(assert) {
@@ -956,13 +960,14 @@ QUnit.test('playlist.add can insert multiple items at a specific index', functio
   const spy = sinon.spy();
 
   this.clock.tick(1);
-  player.on('playlistadd', spy);
+  player.on(['playlistchange', 'playlistadd'], spy);
   playlist.add([4, 5, 6, 7], 1);
   assert.deepEqual(playlist(), [1, 4, 5, 6, 7, 2, 3]);
-  assert.strictEqual(spy.callCount, 1);
-  assert.strictEqual(spy.firstCall.args[0].type, 'playlistadd');
-  assert.strictEqual(spy.firstCall.args[0].index, 1);
-  assert.strictEqual(spy.firstCall.args[0].count, 4);
+  assert.strictEqual(spy.callCount, 2);
+  assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+  assert.strictEqual(spy.secondCall.args[0].type, 'playlistadd');
+  assert.strictEqual(spy.secondCall.args[0].index, 1);
+  assert.strictEqual(spy.secondCall.args[0].count, 4);
 });
 
 QUnit.test('playlist.add throws an error duringplaylistchange', function(assert) {
@@ -984,13 +989,14 @@ QUnit.test('playlist.remove can remove an item at an index', function(assert) {
   const spy = sinon.spy();
 
   this.clock.tick(1);
-  player.on('playlistremove', spy);
+  player.on(['playlistchange', 'playlistremove'], spy);
   playlist.remove(1);
   assert.deepEqual(playlist(), [1, 3]);
-  assert.strictEqual(spy.callCount, 1);
-  assert.strictEqual(spy.firstCall.args[0].type, 'playlistremove');
-  assert.strictEqual(spy.firstCall.args[0].index, 1);
-  assert.strictEqual(spy.firstCall.args[0].count, 1);
+  assert.strictEqual(spy.callCount, 2);
+  assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+  assert.strictEqual(spy.secondCall.args[0].type, 'playlistremove');
+  assert.strictEqual(spy.secondCall.args[0].index, 1);
+  assert.strictEqual(spy.secondCall.args[0].count, 1);
 });
 
 QUnit.test('playlist.remove does nothing when index is out of range', function(assert) {
@@ -999,7 +1005,7 @@ QUnit.test('playlist.remove does nothing when index is out of range', function(a
   const spy = sinon.spy();
 
   this.clock.tick(1);
-  player.on('playlistremove', spy);
+  player.on(['playlistchange', 'playlistremove'], spy);
   playlist.remove(4);
   assert.deepEqual(playlist(), [1, 2, 3]);
   assert.strictEqual(spy.callCount, 0);
@@ -1011,13 +1017,14 @@ QUnit.test('playlist.remove can remove multiple items at an index', function(ass
   const spy = sinon.spy();
 
   this.clock.tick(1);
-  player.on('playlistremove', spy);
+  player.on(['playlistchange', 'playlistremove'], spy);
   playlist.remove(1, 2);
   assert.deepEqual(playlist(), [1]);
-  assert.strictEqual(spy.callCount, 1);
-  assert.strictEqual(spy.firstCall.args[0].type, 'playlistremove');
-  assert.strictEqual(spy.firstCall.args[0].index, 1);
-  assert.strictEqual(spy.firstCall.args[0].count, 2);
+  assert.strictEqual(spy.callCount, 2);
+  assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+  assert.strictEqual(spy.secondCall.args[0].type, 'playlistremove');
+  assert.strictEqual(spy.secondCall.args[0].index, 1);
+  assert.strictEqual(spy.secondCall.args[0].count, 2);
 });
 
 QUnit.test('playlist.remove throws an error duringplaylistchange', function(assert) {


### PR DESCRIPTION
## Description
This was a feature request from a Brightcove customer: the ability to add or remove single items from the playlist without replacing the entire playlist. Seemed like an easy update and one that would be sensible to make!

## Specific Changes proposed
* New `add` function for adding playlist items
* New `remove` function for removing playlist items
* Simplified logic for preparing playlist items so that the `add` and `remove` methods could be added with minimal code duplication
* Updated some metafiles

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
