### PR TITLE
fix: show poster for audioPosterMode playlist

### DIFF
--- a/src/playlist-plugin.js
+++ b/src/playlist-plugin.js
@@ -216,7 +216,8 @@ export default class PlaylistPlugin extends Plugin {
    * @private
    */
   playNext_ = () => {
-    const loadedNext = this.loadNextItem({ loadPoster: false });
+    const shouldLoadPoster = this.player.options_.audioPosterMode ? true : false;
+    const loadedNext = this.loadNextItem({ loadPoster: shouldLoadPoster });
 
     if (loadedNext) {
       this.player.play();


### PR DESCRIPTION
## Description
Inorder to avoid poster flashes in between videos, poster images are hidden in playlists for all but the first video. But since we expect poster images to be displayed for all audioOnly videos, this PR fixes that.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
